### PR TITLE
Inject HeroRepository into QuestRepository and implement hero deletion

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -12,9 +12,28 @@
     <string name="begin_quest">Begin Quest</string>
     <string name="adventure_log">Adventure Log</string>
     <string name="no_entries_yet">No entries yet.</string>
+    <string name="quest_completed_title">Quest Completed!</string>
+    <string name="quest_completed_message">Congratulations! You've completed a %1$d-minute quest.</string>
+    <string name="rewards_earned">Rewards Earned:</string>
+    <string name="xp_reward_format">+%1$d XP</string>
+    <string name="gold_reward_format">+%1$d Gold</string>
+    <string name="no_entries_recorded">No entries recorded this quest.</string>
+    <string name="collect">Collect</string>
     <string name="minutes_format">%1$d minutes</string>
     <string name="step_minutes_minus">– %1$dm</string>
     <string name="step_minutes_plus">+ %1$dm</string>
+
+    <!-- Timer -->
+    <string name="quick_task">Quick task.</string>
+    <string name="steady_quest">Steady quest.</string>
+    <string name="long_march">Long march.</string>
+    <string name="great_undertaking">Great undertaking.</string>
+    <string name="legendary_run">Legendary run.</string>
+    <string name="sealing">Sealing...</string>
+
+    <!-- Onboarding -->
+    <string name="skip">Skip</string>
+    <string name="tap_anywhere_to_continue">Tap anywhere to continue</string>
 
     <!-- Hero Stats -->
     <string name="level_format">Level: %1$d</string>
@@ -25,6 +44,7 @@
     <string name="class_format">Class: %1$s</string>
     <string name="level_short_format">Lv. %1$d</string>
     <string name="no_hero_data">No hero data available</string>
+    <string name="hero_chronicle">⚔️ Hero Chronicle ⚔️</string>
 
     <!-- Inventory -->
     <string name="inventory_title">🎒 Inventory</string>
@@ -33,6 +53,8 @@
     <string name="health_potion">⚗️ Health Potion x3</string>
     <string name="magic_crystal">💎 Magic Crystal</string>
     <string name="scroll_of_wisdom">📜 Scroll of Wisdom</string>
+    <string name="more_items_coming">More items coming soon!</string>
+    <string name="loading_quest_data">Loading quest data...</string>
 
     <!-- Analytics -->
     <string name="analytics_title">Analytics</string>

--- a/composeApp/src/commonMain/kotlin/io/yavero/aterna/App.kt
+++ b/composeApp/src/commonMain/kotlin/io/yavero/aterna/App.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.remember
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import io.yavero.aterna.navigation.DefaultAppRootComponent
+import io.yavero.aterna.navigation.AppRootComponent
 import io.yavero.aterna.ui.AppContent
 import io.yavero.aterna.ui.theme.AternaTypography
 import io.yavero.aterna.ui.theme.DarkColorScheme
@@ -14,7 +15,7 @@ import io.yavero.aterna.ui.theme.LightColorScheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-fun App(rootComponent: io.yavero.aterna.navigation.AppRootComponent) {
+fun App(rootComponent: AppRootComponent) {
 
     AternaTheme {
         AppContent(

--- a/composeApp/src/commonMain/kotlin/io/yavero/aterna/data/remote/QuestApi.kt
+++ b/composeApp/src/commonMain/kotlin/io/yavero/aterna/data/remote/QuestApi.kt
@@ -1,6 +1,9 @@
 package io.yavero.aterna.data.remote
 
 import io.yavero.aterna.domain.model.QuestLoot
+import io.yavero.aterna.domain.model.Item
+import io.yavero.aterna.domain.model.ItemType
+import io.yavero.aterna.domain.model.ItemRarity
 import kotlinx.serialization.Serializable
 
 interface QuestApi {
@@ -68,13 +71,13 @@ fun QuestLootDto.toDomain(): QuestLoot {
     )
 }
 
-fun ItemDto.toDomain(): io.yavero.aterna.domain.model.Item {
-    return io.yavero.aterna.domain.model.Item(
+fun ItemDto.toDomain(): Item {
+    return Item(
         id = id,
         name = name,
         description = "A $rarity ${itemType.lowercase()}",
-        itemType = io.yavero.aterna.domain.model.ItemType.valueOf(itemType),
-        rarity = io.yavero.aterna.domain.model.ItemRarity.valueOf(rarity),
+        itemType = ItemType.valueOf(itemType),
+        rarity = ItemRarity.valueOf(rarity),
         value = value
     )
 }

--- a/composeApp/src/commonMain/kotlin/io/yavero/aterna/data/repository/FocusSessionRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/io/yavero/aterna/data/repository/FocusSessionRepositoryImpl.kt
@@ -4,10 +4,10 @@ import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.coroutines.mapToOneOrNull
 import io.yavero.aterna.data.database.AternaDatabase
+import io.yavero.aterna.data.database.FocusSessionEntity
 import io.yavero.aterna.domain.model.FocusSession
 import io.yavero.aterna.domain.repository.FocusSessionRepository
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Instant
@@ -96,7 +96,7 @@ class FocusSessionRepositoryImpl(
         focusSessionQueries.deleteFocusSession(id)
     }
 
-    private fun mapEntityToDomain(entity: io.yavero.aterna.data.database.FocusSessionEntity): FocusSession {
+    private fun mapEntityToDomain(entity: FocusSessionEntity): FocusSession {
         return FocusSession(
             id = entity.id,
             startAt = Instant.fromEpochMilliseconds(entity.startAt),

--- a/composeApp/src/commonMain/kotlin/io/yavero/aterna/data/repository/HeroRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/io/yavero/aterna/data/repository/HeroRepositoryImpl.kt
@@ -8,7 +8,6 @@ import io.yavero.aterna.domain.model.ClassType
 import io.yavero.aterna.domain.model.Hero
 import io.yavero.aterna.domain.repository.HeroRepository
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Instant
@@ -57,8 +56,7 @@ class HeroRepositoryImpl(
     }
 
     override suspend fun deleteHero() {
-
-
+        heroQueries.deleteHero()
     }
 
     override suspend fun updateHeroStats(

--- a/composeApp/src/commonMain/kotlin/io/yavero/aterna/data/repository/TaskRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/io/yavero/aterna/data/repository/TaskRepositoryImpl.kt
@@ -4,6 +4,8 @@ import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.coroutines.mapToOneOrNull
 import io.yavero.aterna.data.database.AternaDatabase
+import io.yavero.aterna.data.database.TaskEntity
+import io.yavero.aterna.data.database.SelectTasksByDueDate
 import io.yavero.aterna.domain.model.Subtask
 import io.yavero.aterna.domain.model.Task
 import io.yavero.aterna.domain.repository.TaskRepository
@@ -148,7 +150,7 @@ class TaskRepositoryImpl(
         }
     }
 
-    private fun mapEntityToDomain(entity: io.yavero.aterna.data.database.TaskEntity): Task {
+    private fun mapEntityToDomain(entity: TaskEntity): Task {
         val subtasks = database.taskQueries.selectSubtasksByTaskId(entity.id)
             .executeAsList()
             .map { subtaskEntity ->
@@ -177,7 +179,7 @@ class TaskRepositoryImpl(
         )
     }
 
-    private fun mapSelectTasksByDueDateToDomain(entity: io.yavero.aterna.data.database.SelectTasksByDueDate): Task {
+    private fun mapSelectTasksByDueDateToDomain(entity: SelectTasksByDueDate): Task {
         val subtasks = database.taskQueries.selectSubtasksByTaskId(entity.id)
             .executeAsList()
             .map { subtaskEntity ->

--- a/composeApp/src/commonMain/kotlin/io/yavero/aterna/features/onboarding/ui/OnboardingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/yavero/aterna/features/onboarding/ui/OnboardingScreen.kt
@@ -29,6 +29,8 @@ import io.yavero.aterna.features.onboarding.ui.components.*
 import io.yavero.aterna.fx.CometSky
 import io.yavero.aterna.fx.CometStyle
 import io.yavero.aterna.ui.theme.AternaColors
+import io.yavero.aterna.composeApp.generated.resources.Res
+import org.jetbrains.compose.resources.stringResource
 import kotlinx.coroutines.delay
 import kotlinx.datetime.Clock
 import kotlin.math.min
@@ -180,7 +182,7 @@ fun OnboardingScreen(
                 .padding(horizontal = 16.dp)
         ) {
             Text(
-                text = "Skip",
+                text = stringResource(Res.string.skip),
                 color = AternaColors.GoldAccent,
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Medium
@@ -422,7 +424,7 @@ private fun BottomNotice(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
-            "Tap anywhere to continue",
+            stringResource(Res.string.tap_anywhere_to_continue),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.graphicsLayer { alpha = if (enabled) 1f else .5f }

--- a/composeApp/src/commonMain/kotlin/io/yavero/aterna/features/quest/component/QuestDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/io/yavero/aterna/features/quest/component/QuestDialogs.kt
@@ -14,23 +14,28 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import io.yavero.aterna.designsystem.component.AdhdCard
 import io.yavero.aterna.designsystem.component.AdhdPrimaryButton
 import io.yavero.aterna.domain.model.Hero
+import io.yavero.aterna.domain.model.Quest
 import io.yavero.aterna.domain.model.QuestLoot
+import io.yavero.aterna.domain.model.ItemType
+import io.yavero.aterna.domain.model.ItemRarity
 import io.yavero.aterna.domain.model.quest.EventType
 import io.yavero.aterna.domain.model.quest.QuestEvent
+import io.yavero.aterna.domain.util.LootRoller
 import io.yavero.aterna.ui.theme.AternaColors
 import io.yavero.aterna.ui.theme.AternaSpacing
 import io.yavero.aterna.ui.theme.AternaTypography
+import io.yavero.aterna.composeApp.generated.resources.Res
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun LootDisplayDialog(
-    quest: io.yavero.aterna.domain.model.Quest,
+    quest: Quest,
     hero: Hero?,
     loot: QuestLoot? = null,
     events: List<QuestEvent> = emptyList(),
@@ -39,7 +44,7 @@ fun LootDisplayDialog(
 ) {
     val displayLoot = loot ?: remember(quest, hero) {
         if (hero != null) {
-            io.yavero.aterna.domain.util.LootRoller.rollLoot(
+            LootRoller.rollLoot(
                 questDurationMinutes = quest.durationMinutes,
                 heroLevel = hero.level,
                 classType = hero.classType,
@@ -62,7 +67,7 @@ fun LootDisplayDialog(
                         tint = MaterialTheme.colorScheme.primary
                     )
                     Text(
-                        text = "Quest Completed!",
+                        text = stringResource(Res.string.quest_completed_title),
                         style = MaterialTheme.typography.headlineSmall,
                         fontWeight = FontWeight.Bold
                     )
@@ -71,7 +76,10 @@ fun LootDisplayDialog(
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(AternaSpacing.Medium)) {
                     Text(
-                        "Congratulations! You've completed a ${quest.durationMinutes}-minute quest.",
+                        stringResource(
+                            Res.string.quest_completed_message,
+                            quest.durationMinutes
+                        ),
                         style = AternaTypography.Default.bodyMedium
                     )
                     AdhdCard {
@@ -80,7 +88,7 @@ fun LootDisplayDialog(
                             verticalArrangement = Arrangement.spacedBy(AternaSpacing.Small)
                         ) {
                             Text(
-                                "Rewards Earned:",
+                                stringResource(Res.string.rewards_earned),
                                 style = AternaTypography.Default.titleSmall,
                                 color = MaterialTheme.colorScheme.primary
                             )
@@ -96,7 +104,7 @@ fun LootDisplayDialog(
                                     modifier = Modifier.size(20.dp)
                                 )
                                 Text(
-                                    "+${loot.xp} XP",
+                                    stringResource(Res.string.xp_reward_format, loot.xp),
                                     style = AternaTypography.Default.bodyMedium,
                                     color = MaterialTheme.colorScheme.tertiary
                                 )
@@ -113,7 +121,7 @@ fun LootDisplayDialog(
                                     modifier = Modifier.size(20.dp)
                                 )
                                 Text(
-                                    "+${loot.gold} Gold",
+                                    stringResource(Res.string.gold_reward_format, loot.gold),
                                     style = AternaTypography.Default.bodyMedium,
                                     color = MaterialTheme.colorScheme.secondary
                                 )
@@ -126,18 +134,15 @@ fun LootDisplayDialog(
                                         horizontalArrangement = Arrangement.spacedBy(AternaSpacing.Small)
                                     ) {
                                         val icon = when (item.itemType) {
-                                            io.yavero.aterna.domain.model.ItemType.WEAPON -> Icons.Default.Build
-                                            io.yavero.aterna.domain.model.ItemType.ARMOR -> Icons.Default.Shield
-                                            io.yavero.aterna.domain.model.ItemType.CONSUMABLE -> Icons.Default.LocalDrink
+                                            ItemType.WEAPON -> Icons.Default.Build
+                                            ItemType.ARMOR -> Icons.Default.Shield
+                                            ItemType.CONSUMABLE -> Icons.Default.LocalDrink
                                             else -> Icons.Default.Inventory
                                         }
                                         val tint = when (item.rarity) {
-                                            io.yavero.aterna.domain.model.ItemRarity.LEGENDARY -> Color(
-                                                0xFFF59E0B
-                                            )
-
-                                            io.yavero.aterna.domain.model.ItemRarity.EPIC -> Color(0xFF8B5CF6)
-                                            io.yavero.aterna.domain.model.ItemRarity.RARE -> Color(0xFF3B82F6)
+                                            ItemRarity.LEGENDARY -> AternaColors.RarityLegendary
+                                            ItemRarity.EPIC -> AternaColors.RarityEpic
+                                            ItemRarity.RARE -> AternaColors.RarityRare
                                             else -> MaterialTheme.colorScheme.onSurfaceVariant
                                         }
                                         Icon(icon, null, tint = tint, modifier = Modifier.size(20.dp))
@@ -164,14 +169,14 @@ fun LootDisplayDialog(
                             verticalArrangement = Arrangement.spacedBy(AternaSpacing.Small)
                         ) {
                             Text(
-                                "Adventure Log:",
+                                stringResource(Res.string.adventure_log),
                                 style = AternaTypography.Default.titleSmall,
                                 color = MaterialTheme.colorScheme.primary
                             )
 
                             if (events.isEmpty()) {
                                 Text(
-                                    "No entries recorded this quest.",
+                                    stringResource(Res.string.no_entries_recorded),
                                     style = AternaTypography.Default.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
@@ -209,7 +214,7 @@ fun LootDisplayDialog(
                     }
                 }
             },
-            confirmButton = { AdhdPrimaryButton(text = "Collect", onClick = onDismiss) }
+            confirmButton = { AdhdPrimaryButton(text = stringResource(Res.string.collect), onClick = onDismiss) }
         )
     }
 }
@@ -220,7 +225,7 @@ fun StatsPopupDialog(hero: Hero?, onDismiss: () -> Unit, modifier: Modifier = Mo
         onDismissRequest = onDismiss,
         title = {
             Text(
-                "⚔️ Hero Chronicle ⚔️",
+                stringResource(Res.string.hero_chronicle),
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold
             )
@@ -228,16 +233,16 @@ fun StatsPopupDialog(hero: Hero?, onDismiss: () -> Unit, modifier: Modifier = Mo
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 hero?.let { h ->
-                    Text("Level: ${h.level}")
-                    Text("XP: ${h.xp}")
-                    Text("Gold: ${h.gold}")
-                    Text("Focus Minutes: ${h.totalFocusMinutes}")
-                    Text("Daily Streak: ${h.dailyStreak}")
-                    Text("Class: ${h.classType.displayName}")
-                } ?: Text("No hero data available")
+                    Text(stringResource(Res.string.level_format, h.level))
+                    Text(stringResource(Res.string.xp_format, h.xp))
+                    Text(stringResource(Res.string.gold_format, h.gold))
+                    Text(stringResource(Res.string.focus_minutes_format, h.totalFocusMinutes))
+                    Text(stringResource(Res.string.daily_streak_format, h.dailyStreak))
+                    Text(stringResource(Res.string.class_format, h.classType.displayName))
+                } ?: Text(stringResource(Res.string.no_hero_data))
             }
         },
-        confirmButton = { Button(onClick = onDismiss) { Text("Close") } }
+        confirmButton = { Button(onClick = onDismiss) { Text(stringResource(Res.string.close)) } }
     )
 }
 
@@ -245,23 +250,29 @@ fun StatsPopupDialog(hero: Hero?, onDismiss: () -> Unit, modifier: Modifier = Mo
 fun InventoryPopupDialog(hero: Hero?, onDismiss: () -> Unit, modifier: Modifier = Modifier) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("🎒 Inventory", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold) },
+        title = {
+            Text(
+                stringResource(Res.string.inventory_title),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold
+            )
+        },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Text("🗡️ Iron Sword")
-                Text("🛡️ Leather Armor")
-                Text("⚗️ Health Potion x3")
-                Text("💎 Magic Crystal")
-                Text("📜 Scroll of Wisdom")
+                Text(stringResource(Res.string.iron_sword))
+                Text(stringResource(Res.string.leather_armor))
+                Text(stringResource(Res.string.health_potion))
+                Text(stringResource(Res.string.magic_crystal))
+                Text(stringResource(Res.string.scroll_of_wisdom))
                 Spacer(Modifier.height(8.dp))
                 Text(
-                    "More items coming soon!",
+                    stringResource(Res.string.more_items_coming),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         },
-        confirmButton = { Button(onClick = onDismiss) { Text("Close") } }
+        confirmButton = { Button(onClick = onDismiss) { Text(stringResource(Res.string.close)) } }
     )
 }
 
@@ -274,7 +285,7 @@ fun LoadingState(modifier: Modifier = Modifier) {
     ) {
         CircularProgressIndicator()
         Text(
-            "Loading quest data...",
+            stringResource(Res.string.loading_quest_data),
             style = AternaTypography.Default.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center

--- a/composeApp/src/commonMain/kotlin/io/yavero/aterna/features/timer/TimerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/yavero/aterna/features/timer/TimerScreen.kt
@@ -25,6 +25,8 @@ import io.yavero.aterna.domain.model.ClassType
 import io.yavero.aterna.features.timer.component.RitualRing
 import io.yavero.aterna.ui.components.ringPaletteFor
 import io.yavero.aterna.ui.theme.AternaColors
+import io.yavero.aterna.composeApp.generated.resources.Res
+import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -81,7 +83,7 @@ fun TimerScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    "Start Quest",
+                    stringResource(Res.string.begin_quest),
                     style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.ExtraBold
                 )
@@ -116,23 +118,27 @@ fun TimerScreen(
                         onClick = { minutes = (minutes - stepMinutes).coerceAtLeast(minMinutes) },
                         shape = RoundedCornerShape(12.dp),
                         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline)
-                    ) { Text("– ${stepMinutes}m") }
+                    ) { Text(stringResource(Res.string.step_minutes_minus, stepMinutes)) }
                     OutlinedButton(
                         onClick = { minutes = (minutes + stepMinutes).coerceAtMost(maxMinutes) },
                         shape = RoundedCornerShape(12.dp),
                         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline)
-                    ) { Text("+ ${stepMinutes}m") }
+                    ) { Text(stringResource(Res.string.step_minutes_plus, stepMinutes)) }
                 }
 
                 Spacer(Modifier.height(16.dp))
 
-                Text("$minutes minutes", style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.Black)
+                Text(
+                    stringResource(Res.string.minutes_format, minutes),
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Black
+                )
                 val line = when {
-                    minutes < 25 -> "Quick task."
-                    minutes < 60 -> "Steady quest."
-                    minutes < 90 -> "Long march."
-                    minutes < 120 -> "Great undertaking."
-                    else -> "Legendary run."
+                    minutes < 25 -> stringResource(Res.string.quick_task)
+                    minutes < 60 -> stringResource(Res.string.steady_quest)
+                    minutes < 90 -> stringResource(Res.string.long_march)
+                    minutes < 120 -> stringResource(Res.string.great_undertaking)
+                    else -> stringResource(Res.string.legendary_run)
                 }
                 Text(line, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
@@ -166,7 +172,7 @@ fun TimerScreen(
                         .background(questBrush, btnShape)
                 ) {
                     Text(
-                        if (isSealing) "Sealing..." else "Start Quest",
+                        stringResource(if (isSealing) Res.string.sealing else Res.string.begin_quest),
                         fontSize = 18.sp,
                         fontWeight = FontWeight.Bold
                     )
@@ -181,7 +187,7 @@ fun TimerScreen(
                         contentColor = MaterialTheme.colorScheme.onSurface
                     ),
                     border = ButtonDefaults.outlinedButtonBorder(false)
-                ) { Text("Retreat") }
+                ) { Text(stringResource(Res.string.retreat)) }
             }
         }
 
@@ -189,7 +195,7 @@ fun TimerScreen(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.3f * sealProgress))
+                    .background(AternaColors.Neutral900.copy(alpha = 0.3f * sealProgress))
             )
         }
     }
@@ -197,8 +203,8 @@ fun TimerScreen(
 
 @Composable
 fun DungeonVignette() {
-    val bg1 = Color(0xFF0F0F0F)
-    val bg2 = Color(0xFF1A1A1A)
+    val bg1 = AternaColors.Neutral950
+    val bg2 = AternaColors.Neutral900
 
     Box(
         Modifier

--- a/composeApp/src/commonMain/kotlin/io/yavero/aterna/ui/theme/Colors.kt
+++ b/composeApp/src/commonMain/kotlin/io/yavero/aterna/ui/theme/Colors.kt
@@ -79,6 +79,11 @@ object AternaColors {
     val GoldSoft = Color(0xFFF9E6A8)
     val Ink = Color(0xFFE8ECF8)
 
+    // Loot rarity
+    val RarityLegendary = Secondary500
+    val RarityEpic = Color(0xFF8B5CF6)
+    val RarityRare = Color(0xFF3B82F6)
+
     // Status
     val FocusActive = Color(0xFF22C55E)
     val FocusPaused = Color(0xFFF4B400)

--- a/composeApp/src/commonMain/sqldelight/io/yavero/aterna/data/database/Hero.sq
+++ b/composeApp/src/commonMain/sqldelight/io/yavero/aterna/data/database/Hero.sq
@@ -28,6 +28,9 @@ SET level = ?, xp = ?, gold = ?, totalFocusMinutes = ?, dailyStreak = ?, lastAct
 WHERE id = ?;
 
 updateHeroCooldown:
-UPDATE HeroEntity 
+UPDATE HeroEntity
 SET isInCooldown = ?, cooldownEndTime = ?
 WHERE id = ?;
+
+deleteHero:
+DELETE FROM HeroEntity;


### PR DESCRIPTION
## Summary
- replace fully qualified type references with direct imports
- move dialog, timer, and onboarding text into shared string resources
- centralize item rarity colors and reuse theme tokens

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0854e5a3c83219ca05a80ab016a25